### PR TITLE
Improve text extraction API

### DIFF
--- a/src/pdfium/qpdfiumpage.cpp
+++ b/src/pdfium/qpdfiumpage.cpp
@@ -118,21 +118,23 @@ int QPdfiumPage::countChars() const
     return m_pageHolder->m_textPage->CountChars();
 }
 
-int QPdfiumPage::countRects() const
+int QPdfiumPage::countTextRects() const
 {
-    return countRects(0, countChars());
+    return countTextRects(0, countChars());
 }
 
-int QPdfiumPage::countRects(int start, int charCount) const
+int QPdfiumPage::countTextRects(int start, int charCount) const
 {
     return m_pageHolder->m_textPage->CountRects(start, charCount);
 }
 
-QRectF QPdfiumPage::getRect(int rectIndex) const
+QRectF QPdfiumPage::getTextRect(int rectIndex) const
 {
-    FX_FLOAT left, top, right, bottom;
+    //FIXME
+    FX_FLOAT left = 0, top = 0, right = 0, bottom = 0;
     m_pageHolder->m_textPage->GetRect(rectIndex, left, top, right, bottom);
-    return QRectF(left, top, right - left, top - bottom);
+    auto rects = m_pageHolder->m_textPage->GetRectArray(0, countChars());
+    return QRectF(rects[rectIndex].left, rects[rectIndex].top, rects[rectIndex].right - rects[rectIndex].left, rects[rectIndex].top - rects[rectIndex].bottom);
 }
 
 QString QPdfiumPage::text(const QRectF& rect) const

--- a/src/pdfium/qpdfiumpage.cpp
+++ b/src/pdfium/qpdfiumpage.cpp
@@ -118,23 +118,22 @@ int QPdfiumPage::countChars() const
     return m_pageHolder->m_textPage->CountChars();
 }
 
-int QPdfiumPage::countTextRects() const
+std::vector<QRectF> QPdfiumPage::getTextRects(int start, int count) const
 {
-    return countTextRects(0, countChars());
-}
-
-int QPdfiumPage::countTextRects(int start, int charCount) const
-{
-    return m_pageHolder->m_textPage->CountRects(start, charCount);
-}
-
-QRectF QPdfiumPage::getTextRect(int rectIndex) const
-{
+    std::vector<QRectF> result;
+    std::vector<CFX_FloatRect> pdfiumRects = m_pageHolder->m_textPage->GetRectArray(start, count);
+    result.reserve(pdfiumRects.size());
+    for (CFX_FloatRect &rect: pdfiumRects) {
+        result.push_back({rect.left, rect.top, rect.right - rect.left, rect.top - rect.bottom});
+    }
+    return result;
+    /*
     //FIXME
     FX_FLOAT left = 0, top = 0, right = 0, bottom = 0;
     m_pageHolder->m_textPage->GetRect(rectIndex, left, top, right, bottom);
     auto rects = m_pageHolder->m_textPage->GetRectArray(0, countChars());
     return QRectF(rects[rectIndex].left, rects[rectIndex].top, rects[rectIndex].right - rects[rectIndex].left, rects[rectIndex].top - rects[rectIndex].bottom);
+    */
 }
 
 QString QPdfiumPage::text(const QRectF& rect) const

--- a/src/pdfium/qpdfiumpage.cpp
+++ b/src/pdfium/qpdfiumpage.cpp
@@ -118,9 +118,9 @@ int QPdfiumPage::countChars() const
     return m_pageHolder->m_textPage->CountChars();
 }
 
-std::vector<QRectF> QPdfiumPage::getTextRects(int start, int count) const
+QVector<QRectF> QPdfiumPage::getTextRects(int start, int count) const
 {
-    std::vector<QRectF> result;
+    QVector<QRectF> result;
     std::vector<CFX_FloatRect> pdfiumRects = m_pageHolder->m_textPage->GetRectArray(start, count);
     result.reserve(pdfiumRects.size());
     for (CFX_FloatRect &rect: pdfiumRects) {

--- a/src/pdfium/qpdfiumpage.h
+++ b/src/pdfium/qpdfiumpage.h
@@ -40,7 +40,7 @@ public:
     QImage image(qreal scale = 1.0);
 
     int countChars() const;
-    std::vector<QRectF> getTextRects(int start = 0, int charCount = -1) const;
+    QVector<QRectF> getTextRects(int start = 0, int charCount = -1) const;
     QString text(const QRectF &rect) const;
     QString text() const;
     QString text(int start, int charCount) const;

--- a/src/pdfium/qpdfiumpage.h
+++ b/src/pdfium/qpdfiumpage.h
@@ -39,8 +39,13 @@ public:
     int pageIndex() const;
     QImage image(qreal scale = 1.0);
 
-    QString text();
-    QString text(int start, int size);
+    int countChars() const;
+    int countRects() const;
+    int countRects(int start, int charCount) const;
+    QRectF getRect(int rectIndex) const;
+    QString text(const QRectF &rect) const;
+    QString text() const;
+    QString text(int start, int charCount) const;
 
 private:
     QPdfiumPage(QSharedPointer<PageHolder> page, int pageIndex);

--- a/src/pdfium/qpdfiumpage.h
+++ b/src/pdfium/qpdfiumpage.h
@@ -40,9 +40,7 @@ public:
     QImage image(qreal scale = 1.0);
 
     int countChars() const;
-    int countTextRects() const;
-    int countTextRects(int start, int charCount) const;
-    QRectF getTextRect(int rectIndex) const;
+    std::vector<QRectF> getTextRects(int start = 0, int charCount = -1) const;
     QString text(const QRectF &rect) const;
     QString text() const;
     QString text(int start, int charCount) const;

--- a/src/pdfium/qpdfiumpage.h
+++ b/src/pdfium/qpdfiumpage.h
@@ -40,9 +40,9 @@ public:
     QImage image(qreal scale = 1.0);
 
     int countChars() const;
-    int countRects() const;
-    int countRects(int start, int charCount) const;
-    QRectF getRect(int rectIndex) const;
+    int countTextRects() const;
+    int countTextRects(int start, int charCount) const;
+    QRectF getTextRect(int rectIndex) const;
     QString text(const QRectF &rect) const;
     QString text() const;
     QString text(int start, int charCount) const;

--- a/tests/auto/cpp/tst_cpp.cpp
+++ b/tests/auto/cpp/tst_cpp.cpp
@@ -29,7 +29,7 @@ private slots:
     void test_documentDeletion();
     void test_extractText();
     void test_countChars();
-    void test_countRects();
+    void test_countTextRects();
     void test_extractTextRect();
     void test_invalidPdf();
     void test_openPdf();
@@ -95,17 +95,18 @@ void CppTest::test_countChars()
     QVERIFY2(page.countChars() == 2557, "Invalid number of chars");
 }
 
-void CppTest::test_countRects()
+void CppTest::test_countTextRects()
 {
     auto page = m_pdfium->page(0);
-    QVERIFY2(page.countTextRects() == 43, "Invalid number of text rects");
-    QVERIFY2(page.countTextRects(0, 1) == 1, "Invalid number of text rects");
+    auto rects = page.getTextRects();
+    QVERIFY2(rects.size() == 43, "Invalid number of text areas");
 }
 
 void CppTest::test_extractTextRect()
 {
     auto page = m_pdfium->page(0);
-    auto text = page.text(page.getTextRect(1));
+    auto rects = page.getTextRects();
+    auto text = page.text(rects[1]);
     QVERIFY2(text == "Why Propensity Scores", "Invalid text extracted");
 }
 

--- a/tests/auto/cpp/tst_cpp.cpp
+++ b/tests/auto/cpp/tst_cpp.cpp
@@ -106,7 +106,7 @@ void CppTest::test_extractTextRect()
 {
     auto page = m_pdfium->page(0);
     auto rects = page.getTextRects();
-    auto text = page.text(rects[1]);
+    auto text = page.text(rects[0]);
     QVERIFY2(text == "Why Propensity Scores", "Invalid text extracted");
 }
 

--- a/tests/auto/cpp/tst_cpp.cpp
+++ b/tests/auto/cpp/tst_cpp.cpp
@@ -28,6 +28,9 @@ private slots:
     void test_protectedPdf();
     void test_documentDeletion();
     void test_extractText();
+    void test_countChars();
+    void test_countRects();
+    void test_extractTextRect();
     void test_invalidPdf();
     void test_openPdf();
     void test_countPages();
@@ -85,6 +88,27 @@ void CppTest::test_extractText()
     QVERIFY2(text.size() > 0, "Text was not extracted");
     QVERIFY2(text2.size() > 0, "Text was not extracted");
 }
+
+void CppTest::test_countChars()
+{
+    auto page = m_pdfium->page(0);
+    QVERIFY2(page.countChars() == 2557, "Invalid number of chars");
+}
+
+void CppTest::test_countRects()
+{
+    auto page = m_pdfium->page(0);
+    QVERIFY2(page.countTextRects() == 43, "Invalid number of text rects");
+    QVERIFY2(page.countTextRects(0, 1) == 1, "Invalid number of text rects");
+}
+
+void CppTest::test_extractTextRect()
+{
+    auto page = m_pdfium->page(0);
+    auto text = page.text(page.getTextRect(1));
+    QVERIFY2(text == "Why Propensity Scores", "Invalid text extracted");
+}
+
 
 void CppTest::test_invalidPdf()
 {


### PR DESCRIPTION
Extracting the text from the whole page is a nice feature, but the pdfium API makes it possible to extract pieces of the page instead.
Expose the TextRect API (and working around its dangerous calls), with associated unit tests.
Cf. #4 and sorry for the delay...